### PR TITLE
Fix auth bugs and improve deployment

### DIFF
--- a/app/Http/Middleware/NoStoreCache.php
+++ b/app/Http/Middleware/NoStoreCache.php
@@ -14,6 +14,17 @@ class NoStoreCache
         $response = $next($request);
         $response->headers->set('Cache-Control', 'no-store, no-cache, must-revalidate');
         $response->headers->set('Pragma', 'no-cache');
+        $response->headers->set('Expires', '0');
+        $existingVary = $response->headers->get('Vary');
+        $varyValues = array_filter(array_map('trim', explode(',', (string) $existingVary)));
+        foreach (['Cookie', 'Authorization'] as $value) {
+            if (!in_array($value, $varyValues, true)) {
+                $varyValues[] = $value;
+            }
+        }
+        if (!empty($varyValues)) {
+            $response->headers->set('Vary', implode(', ', $varyValues));
+        }
         return $response;
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,7 +28,7 @@ Route::get('/analytics/snapshot', [VisitorController::class, 'snapshot']);
 Route::get('/csrf-token', [AuthController::class, 'csrf']);
 
 // Sanctum CSRF cookie route (for SPA authentication)
-Route::get('/sanctum/csrf-cookie', [\Laravel\Sanctum\Http\Controllers\CsrfCookieController::class, 'show'])->middleware('web');
+Route::get('/sanctum/csrf-cookie', [\Laravel\Sanctum\Http\Controllers\CsrfCookieController::class, 'show'])->middleware(['web','no-store']);
 
 Route::post('/auth/login', [AuthController::class, 'login'])->middleware(['web','no-store']);
 Route::post('/auth/register', [AuthController::class, 'register'])->middleware(['web','no-store']);


### PR DESCRIPTION
Resolves critical authentication issues, including the 'double login after logout' bug, UI flicker, and Safari blank page, by enhancing server-side cache control and client-side auth call serialization.

The 'double login after logout' bug was primarily caused by stale CSRF tokens and cached session data, leading to race conditions. This PR addresses these by ensuring fresh CSRF cookies are fetched, implementing strong `no-store` cache headers on all authentication endpoints, and serializing client-side authentication requests to prevent concurrent state updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d7091a0-a22d-42c4-b76c-ba78576a93f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d7091a0-a22d-42c4-b76c-ba78576a93f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

